### PR TITLE
fix: ensure \	rust_remote_code=True\ for tokenizer loading (Fixes #20)

### DIFF
--- a/omnigenbench/src/utility/model_hub/model_hub.py
+++ b/omnigenbench/src/utility/model_hub/model_hub.py
@@ -740,6 +740,7 @@ class ModelHub:
         )
 
         metadata = ModelHub._load_metadata(path)
+        kwargs.setdefault("trust_remote_code", True)
         tokenizer = OmniTokenizer.from_pretrained(path, **kwargs)
 
         model = None


### PR DESCRIPTION
This PR resolves Issue #20 by adding \	rust_remote_code=True\ when initializing the tokenizer in \ModelHub.load\. This allows custom models such as \
ucleotide-transformer-v2-500m-multi-species\ to be loaded correctly, since they rely on remote code execution for their custom tokenizers/architectures.